### PR TITLE
Allow renderable `with` content.

### DIFF
--- a/spline/components/tasks.py
+++ b/spline/components/tasks.py
@@ -16,6 +16,7 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # pylint: disable=no-member
+import ast
 import os
 import multiprocessing
 from contextlib import closing
@@ -100,7 +101,17 @@ class Tasks(object):
             if key in ['python']:
                 entry['type'] = key
 
-            for item in entry['with'] if 'with' in entry else ['']:
+            if 'with' in entry and isinstance(entry['with'], str):
+                rendered_with = ast.literal_eval(render(entry['with'],
+                                                        variables=self.pipeline.variables,
+                                                        model=self.pipeline.model,
+                                                        env=self.get_merged_env(include_os=True)))
+            elif 'with' in entry:
+                rendered_with = entry['with']
+            else:
+                rendered_with = ['']
+
+            for item in rendered_with:
                 shells.append({
                     'id': self.next_task_id,
                     'creator': key,

--- a/spline/components/tasks.py
+++ b/spline/components/tasks.py
@@ -16,10 +16,10 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # pylint: disable=no-member
-import ast
 import os
 import multiprocessing
 from contextlib import closing
+import ast
 from spline.components.bash import Bash
 from spline.components.docker import Container, Image
 from spline.components.packer import Packer

--- a/spline/validation.py
+++ b/spline/validation.py
@@ -64,7 +64,7 @@ class Validator(object):
                         'script': And(Or(type(' '), type(u' ')), len),
                         Optional('title'): And(str, len),
                         Optional('tags'): And([And(str, len)], len),
-                        Optional('with'): And(len, [object]),
+                        Optional('with'): And(len, Or(type(' '), type(u' '), [object])),
                         Optional('variable'):
                             And(Or(type(' '), type(u' ')), len, Regex(r'([a-zA-Z][_a-zA-Z]*)')),
                         Optional('when', default=''): And(str, Condition.is_valid)

--- a/tests/bats/pipeline-018.bats
+++ b/tests/bats/pipeline-018.bats
@@ -1,0 +1,14 @@
+SCRIPT="python ${WORKSPACE}/scripts/spline"
+
+@test "$BATS_TEST_FILENAME :: Testing Tasks With using a model" {
+    run ${SCRIPT} --definition=${WORKSPACE}/tests/bats/pipeline-018.yaml
+    # verifying exit code
+    [ ${status} -eq 0 ]
+    # verifying output
+    [[ "$output" =~ "---1---" ]]
+    [[ "$output" =~ "---2---" ]]
+    [[ "$output" =~ "---3---" ]]
+
+    result=$(echo "$output" | grep -- '---' | wc -l)
+    [ $result -eq 3 ]
+}

--- a/tests/bats/pipeline-018.yaml
+++ b/tests/bats/pipeline-018.yaml
@@ -1,0 +1,12 @@
+model:
+  data:
+    - 1
+    - 2
+    - 3
+
+pipeline:
+  - stage(setup):
+    - tasks(ordered):
+      - shell:
+          script: echo "---{{ item }}---"
+          with: "{{ model.data }}"

--- a/tests/components/test_tasks.py
+++ b/tests/components/test_tasks.py
@@ -1,5 +1,5 @@
 """Testing of class Tasks."""
-# pylint: disable=no-self-use, invalid-name
+# pylint: disable=no-self-use, invalid-name, too-many-public-methods
 import unittest
 from hamcrest import assert_that, equal_to
 
@@ -190,3 +190,23 @@ class TestTasks(unittest.TestCase):
         assert_that(len(output), equal_to(2))
         assert_that(output[0], equal_to('hello1'))
         assert_that(output[1], equal_to('hello1'))
+
+    def test_tasks_ordered_having_with(self):
+        """Testing with two task only (ordered)."""
+        pipeline = FakePipeline()
+        tasks = Tasks(pipeline, parallel=False)
+        pipeline.model = {'foo': [4, 5, 6]}
+
+        document = [{'shell': {'script': '''echo test:{{ item }}''', 'when': '', 'with': [1, 2, 3]}},
+                    {'shell': {'script': '''echo test:{{ item }}''', 'when': '', 'with': "{{ model.foo }}"}}]
+        result = tasks.process(document)
+        output = [line for line in result['output'] if line.find("test:") >= 0]
+
+        assert_that(result['success'], equal_to(True))
+        assert_that(len(output), equal_to(6))
+        assert_that(output[0], equal_to('test:1'))
+        assert_that(output[1], equal_to('test:2'))
+        assert_that(output[2], equal_to('test:3'))
+        assert_that(output[3], equal_to('test:4'))
+        assert_that(output[4], equal_to('test:5'))
+        assert_that(output[5], equal_to('test:6'))


### PR DESCRIPTION
This patch permits the `with` option, of `tasks`, to contain
Jinja2 renderable content. This is useful when the `models`
section contains data to be reused across a number of `tasks`.