### PR TITLE
Do not assume that /tmp is in use.

### DIFF
--- a/tests/components/test_bash.py
+++ b/tests/components/test_bash.py
@@ -97,12 +97,12 @@ class TestBash(unittest.TestCase):
         bash = Bash(ShellConfig(script='''echo "PIPELINE_BASH_FILE=$PIPELINE_BASH_FILE"'''))
         output = [line for line in bash.process() if line.lower().find("script") > 0]
         assert_that(len(output), equal_to(1))
-        assert_that(output[0], matches_regexp('PIPELINE_BASH_FILE=/tmp/pipeline-script-.*.sh'))
+        assert_that(output[0], matches_regexp('PIPELINE_BASH_FILE=.*/tmp/pipeline-script-.*.sh'))
 
         bash = Bash(ShellConfig(script='''echo "PIPELINE_BASH_FILE={{ env.PIPELINE_BASH_FILE }}"'''))
         output = [line for line in bash.process() if line.lower().find("script") > 0]
         assert_that(len(output), equal_to(1))
-        assert_that(output[0], matches_regexp('PIPELINE_BASH_FILE=/tmp/pipeline-script-.*.sh'))
+        assert_that(output[0], matches_regexp('PIPELINE_BASH_FILE=.*/tmp/pipeline-script-.*.sh'))
 
     def test_dry_run(self):
         """Testing simple bash script in dry run mode."""


### PR DESCRIPTION
This patch permits any directory ending in `/tmp` to be used,
when running the suite of unit-tests.