### PR TITLE
Recursively expand Jinja2 templates

### DIFF
--- a/spline/components/docker.py
+++ b/spline/components/docker.py
@@ -55,7 +55,7 @@ class Container(Bash):
         with open(template_file) as handle:
             template = handle.read()
             # all fields are re-rendered via the Bash script
-            wrapped_script = render(template, container={
+            wrapped_script = render(template, recursive=False, container={
                 'image': 'centos:7' if 'image' not in entry else entry['image'],
                 'remove': True if 'remove' not in entry else str(entry['remove']).lower(),
                 'background': False if 'background' not in entry else str(entry['background']).lower(),

--- a/spline/tools/filters.py
+++ b/spline/tools/filters.py
@@ -20,7 +20,7 @@ from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from spline.tools.logger import Logger
 
 
-def render(value, **kwargs):
+def render(value, recursive=True, **kwargs):
     """
     Use Jinja2 rendering for given text an key key/values.
 
@@ -48,8 +48,13 @@ def render(value, **kwargs):
         environment.filters['docker_environment'] = docker_environment
         environment.filters['find_matrix'] = find_matrix
         environment.filters['find_stages'] = find_stages
-        template = environment.from_string(value)
-        return template.render(**kwargs)
+        prev = value
+        while True:
+            curr = environment.from_string(prev).render(**kwargs)
+            if recursive and curr != prev:
+                prev = curr
+            else:
+                return curr
     except UndefinedError as exception:
         Logger.get_logger(__name__).error("render(undefined): %s", exception)
     except TemplateSyntaxError as exception:

--- a/tests/bats/pipeline-019.bats
+++ b/tests/bats/pipeline-019.bats
@@ -1,0 +1,9 @@
+SCRIPT="python ${WORKSPACE}/scripts/spline"
+
+@test "$BATS_TEST_FILENAME :: Testing recursive Jinja2 template" {
+    run ${SCRIPT} --definition=${WORKSPACE}/tests/bats/pipeline-019.yaml
+    # verifying exit code
+    [ ${status} -eq 0 ]
+    # verifying output
+    [[ "$output" =~ "test:env foo-The answer is 42." ]]
+}

--- a/tests/bats/pipeline-019.yaml
+++ b/tests/bats/pipeline-019.yaml
@@ -1,0 +1,13 @@
+model:
+  bar: 42
+  foo: "The answer is {{ model.bar }}."
+
+pipeline:
+  - stage(setup):
+    - tasks(ordered):
+      - env:
+          foo: env foo
+
+      - shell:
+          script: echo "test:{{ env.foo }}-{{ model.foo }}"
+          title: test


### PR DESCRIPTION
This patch introduces automatic expansion of Jinja2 templates,
except the Docker set-up related templates.

A direct benefit of this patch is one's pipeline configuration
becomes less complex; with many Jinja2 `render` filters
used everywhere becoming unnecessary.