### PR TITLE
Add the ability for Tasks to be automatically retried on failure

### DIFF
--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -123,6 +123,20 @@ list of tasks to be processed and it depends on the setup of the **tasks**
 block whether those tasks are executed in **order** or in **parallel**.
 Please have a look and try the example **with.yaml** in the repository.
 
+"Retries" attribute
+-------------------
+Using the **retries** attribute, one can automatically have a failed shell retried
+up the number of attempts specified.
+
+An example of usage is the following:
+
+::
+
+    - shell:
+        script: |
+            echo "wont work" && false
+        retries: 3
+
 Colors
 ------
 Colors are working fine!

--- a/spline/validation.py
+++ b/spline/validation.py
@@ -67,7 +67,8 @@ class Validator(object):
                         Optional('with'): And(len, [object]),
                         Optional('variable'):
                             And(Or(type(' '), type(u' ')), len, Regex(r'([a-zA-Z][_a-zA-Z]*)')),
-                        Optional('when', default=''): And(str, Condition.is_valid)
+                        Optional('when', default=''): And(str, Condition.is_valid),
+                        Optional('retries', default=1): int
                     }},
                     # optional Docker container task
                     {Optional('docker(container)'): {

--- a/tests/components/test_tasks.py
+++ b/tests/components/test_tasks.py
@@ -1,5 +1,5 @@
 """Testing of class Tasks."""
-# pylint: disable=no-self-use, invalid-name
+# pylint: disable=no-self-use, invalid-name, too-many-public-methods
 import unittest
 from hamcrest import assert_that, equal_to
 
@@ -190,3 +190,15 @@ class TestTasks(unittest.TestCase):
         assert_that(len(output), equal_to(2))
         assert_that(output[0], equal_to('hello1'))
         assert_that(output[1], equal_to('hello1'))
+
+    def test_tasks_ordered_with_retry(self):
+        """Testing with one task only, having a retry given. (ordered)."""
+        pipeline = FakePipeline()
+        tasks = Tasks(pipeline, parallel=False)
+
+        document = [{'shell': {'script': '''echo test:text && false''', 'when': '', 'retries': 3}}]
+        result = tasks.process(document)
+        output = [line for line in result['output'] if line.find("test:") >= 0]
+
+        assert_that(result['success'], equal_to(False))
+        assert_that(len(output), equal_to(3))


### PR DESCRIPTION
This patch introduces the `retries` parameter to all Task based objects,
such as Bash, and permits an end-user to have a given task automatically
retried up-to-N times (the `retries` integer parameter gives N) before
completely failing the task execution.