### PR TITLE
 Support `raw` while recursively rendering Jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='spline',
       author='Thomas Lehmann',
       author_email='thomas.lehmann.private@gmail.com',
       license="MIT",
-      install_requires=["click", "pyaml", "jinja2", "schema"],
+      install_requires=["click", "pyaml", "jinja2", "schema", "six"],
       packages=find_packages(exclude=['tests', 'tests.*']),
       scripts=['scripts/spline'],
       package_data={'spline': [

--- a/spline/components/docker.py
+++ b/spline/components/docker.py
@@ -15,7 +15,7 @@
 # DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-# pylint: disable=useless-super-delegation
+# pylint: disable=useless-super-delegation,bad-continuation
 import os
 import tempfile
 
@@ -55,14 +55,17 @@ class Container(Bash):
         with open(template_file) as handle:
             template = handle.read()
             # all fields are re-rendered via the Bash script
-            wrapped_script = render(template, recursive=False, container={
-                'image': 'centos:7' if 'image' not in entry else entry['image'],
-                'remove': True if 'remove' not in entry else str(entry['remove']).lower(),
-                'background': False if 'background' not in entry else str(entry['background']).lower(),
-                'mount': False if 'mount' not in entry else str(entry['mount']).lower(),
-                'network': '' if 'network' not in entry else entry['network'],
-                'script': config.script
-            })
+            wrapped_script = render(template, recursive=False, env=config.env,
+                model=config.model, item=config.item,  # noqa: E128
+                variables=config.variables, container={  # noqa: E128
+                    'image': 'centos:7' if 'image' not in entry else entry['image'],
+                    'remove': True if 'remove' not in entry else str(entry['remove']).lower(),
+                    'background': False if 'background' not in entry else str(entry['background']).lower(),
+                    'mount': False if 'mount' not in entry else str(entry['mount']).lower(),
+                    'network': '' if 'network' not in entry else entry['network'],
+                    'script': config.script
+                }
+            )
 
             config.script = wrapped_script
 

--- a/tests/components/test_render.py
+++ b/tests/components/test_render.py
@@ -4,8 +4,7 @@ import unittest
 from hamcrest import assert_that, equal_to
 
 from spline.components.bash import Bash
-from spline.components.tasks import Tasks, worker
-from spline.components.hooks import Hooks
+from spline.components.tasks import Tasks
 from spline.components.config import ApplicationOptions, ShellConfig
 from spline.pipeline import PipelineData
 

--- a/tests/components/test_render.py
+++ b/tests/components/test_render.py
@@ -86,4 +86,3 @@ class TestRender(unittest.TestCase):
         output = [line for line in bash.process() if len(line) > 0]
         assert_that(len(output), equal_to(1))
         assert_that(output[0], equal_to('hello'))
-

--- a/tests/components/test_render.py
+++ b/tests/components/test_render.py
@@ -1,0 +1,89 @@
+"""Testing of Jinja2 rendering."""
+# pylint: disable=no-self-use, invalid-name
+import unittest
+from hamcrest import assert_that, equal_to
+
+from spline.components.bash import Bash
+from spline.components.tasks import Tasks, worker
+from spline.components.hooks import Hooks
+from spline.components.config import ApplicationOptions, ShellConfig
+from spline.pipeline import PipelineData
+
+
+class FakePipeline(object):
+    """Fake pipeline class for tests."""
+
+    def __init__(self, hooks=None):
+        """Initialization of fake pipeline."""
+        self.data = PipelineData(hooks)
+        self.model = {}
+        self.options = ApplicationOptions(definition='fake.yaml')
+        self.variables = {}
+
+
+class TestRender(unittest.TestCase):
+    """Testing of render function."""
+
+    def test_render_no_raw(self):
+        """Testing with a task only (ordered)."""
+        pipeline = FakePipeline()
+        tasks = Tasks(pipeline, parallel=False)
+
+        document = [{'env': {'a': '''hello1'''}},
+                    {'shell': {'script': '''echo {{ env.a }}''', 'when': ''}}]
+        result = tasks.process(document)
+        output = [line for line in result['output'] if line.find("hello") >= 0]
+
+        assert_that(result['success'], equal_to(True))
+        assert_that(len(output), equal_to(1))
+        assert_that(output[0], equal_to('hello1'))
+
+    def test_render_one_raw(self):
+        """Testing with a task only (ordered)."""
+        pipeline = FakePipeline()
+        tasks = Tasks(pipeline, parallel=False)
+
+        document = [{'env': {'a': '''hello1'''}},
+                    {'shell': {'script': '''echo "{% raw %}{{ env.a }}{% endraw %}"''', 'when': ''}}]
+        result = tasks.process(document)
+        output = [line for line in result['output'] if line.find("{{") >= 0]
+
+        assert_that(result['success'], equal_to(True))
+        assert_that(len(output), equal_to(1))
+        assert_that(output[0], equal_to('{{ env.a }}'))
+
+    def test_render_one_env_raw(self):
+        """Testing with a task only (ordered)."""
+        pipeline = FakePipeline()
+        tasks = Tasks(pipeline, parallel=False)
+
+        document = [{'env': {'a': '''{% raw %}{{ hello1 }}{% endraw %}'''}},
+                    {'shell': {'script': '''echo "{{ env.a }}"''', 'when': ''}}]
+        result = tasks.process(document)
+        output = [line for line in result['output'] if line.find("{{") >= 0]
+
+        assert_that(result['success'], equal_to(True))
+        assert_that(len(output), equal_to(1))
+        assert_that(output[0], equal_to('{{ hello1 }}'))
+
+    def test_render_one_env_self_referencing_raw(self):
+        """Testing with a task only (ordered)."""
+        pipeline = FakePipeline()
+        tasks = Tasks(pipeline, parallel=False)
+
+        document = [{'env': {'a': '''{% raw %}{{ hello1 }}{% endraw %}''', 'b': "{{ env.a }}"}},
+                    {'shell': {'script': '''echo "{{ env.b }}"''', 'when': ''}}]
+        result = tasks.process(document)
+        output = [line for line in result['output'] if line.find("{{") >= 0]
+
+        assert_that(result['success'], equal_to(True))
+        assert_that(len(output), equal_to(1))
+        assert_that(output[0], equal_to('{{ hello1 }}'))
+
+    def test_render_script_only(self):
+        """Testing rendering of a simple bash script."""
+        bash = Bash(ShellConfig(script='''echo {% raw %}"hello"{% endraw %}'''))
+        output = [line for line in bash.process() if len(line) > 0]
+        assert_that(len(output), equal_to(1))
+        assert_that(output[0], equal_to('hello'))
+


### PR DESCRIPTION
Add support for the Jinja2 `raw` directive, while recursively rendering Jinja2 templates.

Fixes #104.